### PR TITLE
Updated SQL's task  & tasks.ts to use title instead of name

### DIFF
--- a/src/server/db/tasks.ts
+++ b/src/server/db/tasks.ts
@@ -1,17 +1,19 @@
 import { Query } from "./index";
 
 // This defines a function ("all") which will return all tasks using the Query function defined in index.ts
+// , users.name
 const allTasks = async () =>
     await Query(`
-    select tasks.id, tasks.name, tasks.details, tasks.difficulty, tasks.priority, tasks.completed, users.name
+    select tasks.id, tasks.title, tasks.details, tasks.difficulty, tasks.priority, tasks.completed
     from tasks
     join users on tasks.userid = users.id
 `);
 
 // This defines a function ("one") which will return one specific task using the Query function defined in index.ts
+// , 
 const oneTask = async (id: string) =>
     await Query(`
-    select tasks.id, tasks.name, tasks.details, tasks.difficulty, tasks.priority, tasks.completed, users.name
+    select tasks.id, tasks.title, tasks.details, tasks.difficulty, tasks.priority, tasks.completed
     from tasks
     join users on tasks.userid = users.id
     where tasks.id = ?;
@@ -21,7 +23,7 @@ const oneTask = async (id: string) =>
 // Not sure if this is necessary, but this should return all tasks from ONE specific user (targeting userid)
 const allTasksFromUser = async (id: string) =>
     await Query(`
-    select tasks.id, tasks.name, tasks.details, tasks.difficulty, tasks.priority, tasks.completed, users.name
+    select tasks.id, tasks.title, tasks.details, tasks.difficulty, tasks.priority, tasks.completed
     from tasks
     join users on tasks.userid = users.id
     where tasks.userid = ?;

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -19,9 +19,9 @@ router.post("/", async (req, res) => {
     const taskObj: task = req.body;
 
     try {
-        const newUser = await db.Users.post(taskObj.userid, taskObj.name, taskObj.details, taskObj.difficulty, taskObj.priority, taskObj.completed);
+        const newUser = await db.Users.post(taskObj.userid, taskObj.title, taskObj.details, taskObj.difficulty, taskObj.priority, taskObj.completed);
 
-        await db.Tasks.post(taskObj.userid, taskObj.name, taskObj.details, taskObj.difficulty, taskObj.priority, taskObj.completed);
+        await db.Tasks.post(taskObj.userid, taskObj.title, taskObj.details, taskObj.difficulty, taskObj.priority, taskObj.completed);
 
         res.send("success");
 
@@ -58,7 +58,7 @@ router.post("/", async (req, res) => {
 interface task {
     id?: string;
     userid: string;
-    name: string;
+    title: string;
     details: string;
     difficulty: string;
     priority: string;


### PR DESCRIPTION
There was a weird crossover with using the column "name" on both `tasks` and `users` tables, so we changed the column under `tasks` to "title" to prevent any errors there.